### PR TITLE
Speedier `Sqids.new` 🦑

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ id = sqids.encode([1, 2, 3]) # 'se8ojk'
 numbers = sqids.decode(id) # [1, 2, 3]
 ```
 
+> [!WARNING]  
+> If you provide a large custom blocklist and/or custom alphabet, calls to `Sqid.new` can take 
+> ~1ms. You should create a singleton instance of `Sqid` at service start and reusing that rather than
+> repeatedly calling `Squid.new`
+
 ## 📝 License
 
 [MIT](LICENSE)

--- a/lib/sqids.rb
+++ b/lib/sqids.rb
@@ -29,9 +29,19 @@ class Sqids
             "Minimum length has to be between 0 and #{min_length_limit}"
     end
 
-    filtered_blocklist = blocklist.select do |word|
-      word.length >= 3 && (word.downcase.chars - alphabet.downcase.chars).empty?
-    end.to_set(&:downcase)
+    filtered_blocklist = if blocklist == DEFAULT_BLOCKLIST && alphabet == DEFAULT_ALPHABET
+                           # If the blocklist is the default one, we don't need to filter it
+                           # we already know it's valid (lowercase and words longer than 3 chars)
+                           blocklist
+                         else
+                           # Downcase the alphabet once, rather than in the loop, to save significant time
+                           # with large blocklists
+                           downcased_alphabet = alphabet.downcase.chars
+                           # Filter the blocklist
+                           blocklist.select do |word|
+                             word.length >= 3 && (word.downcase.chars - downcased_alphabet).empty?
+                           end.to_set(&:downcase)
+                         end
 
     @alphabet = shuffle(alphabet)
     @min_length = min_length


### PR DESCRIPTION
With the current implementation a call to `Sqid.new` can take ~3/4ms.

This improves this in two ways:

1. If the Default alphabet and blocklist are used, skip filtering, as they already meet the rules

    That gets `Sqid.new` down from ~3ms to 0.07ms

2. When not using defaults, move `alphabet.downcase` out of the `select` loop, so we don't call it once per block list item.

   That gets us from 3.315ms to 0.95ms 🥳

Numbers and benchmarking approach in this issue here:
Fixes #6
