### PR TITLE
mapping numbers to integers in encode to prevent float division issues

### DIFF
--- a/lib/sqids.rb
+++ b/lib/sqids.rb
@@ -51,7 +51,7 @@ class Sqids
   def encode(numbers)
     return '' if numbers.empty?
 
-    in_range_numbers = numbers.select { |n| n >= 0 && n <= Sqids.max_value }
+    in_range_numbers = numbers.map(&:to_i).select { |n| n >= 0 && n <= Sqids.max_value }
     unless in_range_numbers.length == numbers.length
       raise ArgumentError,
             "Encoding supports numbers between 0 and #{Sqids.max_value}"

--- a/spec/encoding_spec.rb
+++ b/spec/encoding_spec.rb
@@ -100,6 +100,14 @@ describe 'Sqids' do
     expect(sqids.encode([])).to eq('')
   end
 
+  it 'encoding with float' do
+    sqids = Sqids.new
+    float = 3.14159265
+    encoded_float = sqids.encode([float])
+    encoded_int = sqids.encode([float.to_i])
+    expect(encoded_float).to eq(encoded_int)
+  end
+
   it 'decoding empty string' do
     sqids = Sqids.new
     expect(sqids.decode('')).to eq([])


### PR DESCRIPTION
This fixes issue with `to_id` function creating large strings due to float division errors
I've implemented a fix casting all values in the given array to an integer before calling the internal `encode_numbers`
Example of the issue.
```
irb(main):098> to_id(1.1, "abc")
=> "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"
```